### PR TITLE
Ignorovat .DS_Store soubory na Macu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 /_tmp/**
 *~
 
+# Mac Finder files
+*.DS_Store
+
 # IDE files
 .idea
 .vscode


### PR DESCRIPTION
Tento PR nastavuje, aby se ignorovaly soubory .DS_Store, které automaticky vytváří Mac Finder.